### PR TITLE
Now for something completely different

### DIFF
--- a/hooker/api.py
+++ b/hooker/api.py
@@ -1,4 +1,6 @@
 import importlib
+import sys, os
+import inspect
 
 from .event_list import EventList
 from .logger import logger
@@ -13,24 +15,30 @@ if "FileNotFoundError" not in globals():
     FileNotFoundError = IOError
 
 
-def hook(event=None, dependencies=None):
+def reset():
+    global EVENTS, WATERFALL
+    EVENTS = EventList()
+    WATERFALL = EventList(is_waterfall=True)
+
+
+def hook(event='*', dependencies=None, event_list=EVENTS):
     """Hooking decorator. Just `@hook(event, dependencies)` on your function
 
     Kwargs:
         event (str): String or Iterable with events to hook
-        dependencies (str): String or Iterable with modules whose hooks have
-        to be called before this one for **this** event
+        dependencies (str): String or Iterable with module names whose hooks have
+            to be called before this one for **this** event
 
     Wraps :func:`EventList.hook`
     """
 
     def wrapper(func):
         """I'm a simple wrapper that manages event hooking"""
-        EVENTS.hook(func, event, dependencies)
+        event_list.hook(func, event, dependencies)
         return func
     return wrapper
 
-def load(path):
+def load(path, overwrite=True):
     """Helper function that tries to load a filepath (or python module notation)
     as a python module and on failure `exec` it.
 
@@ -40,15 +48,40 @@ def load(path):
     The function tries to import `example.module` when either `example.module`,
     `example/module` or `example/module.py` is given.
     """
+    if path.startswith("http://") or path.startswith("https://"):
+        import httpimport
+        url, module = path.split("/", -1)
+        with httpimport.remote_repo(url):
+            __import__(module)
+        return
+
+        raise Exception("Loading plugins through HTTP/S is not implemented.")
+
+
+    logger.info("Loading plugin at '%s'" % (path))
 
     importpath = path.replace("/", ".").replace("\\", ".")
-    if importpath[-3:] == ".py":
-        importpath = importpath[:-3]
+    if importpath.endswith(".py"):  # Remove the file extension
+        importpath = ".".join(importpath.split(".")[:-1])
+        logger.info("Plugin module at '%s'" % (importpath))
 
     try:
-        importlib.import_module(importpath)
+        if overwrite and importpath in sys.modules:
+            logger.info("Overwriting plugin '%s'!" % (importpath))
+            importlib.reload(importpath)
+        else:
+            importlib.import_module(importpath)
     except (ModuleNotFoundError, ImportError, TypeError):
+        logger.warning("Failed loading '%s' as module ('%s'). Trying execution as file..." % (path, importpath))
+
         try:
-            exec(open(path).read())
+            with open(path) as f:
+                exec(f.read())
         except FileNotFoundError:
-            logger.error("Module or file %s was not found! Ignoring...", importpath)
+            logger.error("Module or file '%s' was not found! Ignoring...", importpath)
+
+def get_event_name():
+    try:    # _getframe is faster but implementation specific
+        return sys._getframe(2).f_locals['event_name']
+    except:
+        return inspect.stack()[2].frame.f_locals['event_name']

--- a/hooker/api.py
+++ b/hooker/api.py
@@ -21,20 +21,22 @@ def reset():
     WATERFALL = EventList(is_waterfall=True)
 
 
-def hook(event='*', dependencies=None, event_list=EVENTS):
+def hook(event='*', dependencies=None, event_list=EVENTS, expand=True):
     """Hooking decorator. Just `@hook(event, dependencies)` on your function
 
     Kwargs:
         event (str): String or Iterable with events to hook
         dependencies (str): String or Iterable with module names whose hooks have
             to be called before this one for **this** event
+        event_list (EventList): The EventList object that will get assigned the hooked event
+        expand (bool): Whether to interpret the 'event' as a glob
 
     Wraps :func:`EventList.hook`
     """
 
     def wrapper(func):
         """I'm a simple wrapper that manages event hooking"""
-        event_list.hook(func, event, dependencies)
+        event_list.hook(func, event, dependencies, expand=expand)
         return func
     return wrapper
 
@@ -81,7 +83,9 @@ def load(path, overwrite=True):
             logger.error("Module or file '%s' was not found! Ignoring...", importpath)
 
 def get_event_name():
-    try:    # _getframe is faster but implementation specific
-        return sys._getframe(2).f_locals['event_name']
-    except:
-        return inspect.stack()[2].frame.f_locals['event_name']
+    for i in range(10):
+        try:    # _getframe is faster but implementation specific
+            return sys._getframe(i).f_locals['event_name']
+            # return inspect.stack()[1].frame.f_locals['event_name']
+        except:
+            continue

--- a/hooker/api.py
+++ b/hooker/api.py
@@ -89,3 +89,6 @@ def get_event_name():
             # return inspect.stack()[1].frame.f_locals['event_name']
         except:
             continue
+
+def events(pattern='*'):
+    return EVENTS._match_event(pattern)

--- a/hooker/event_list.py
+++ b/hooker/event_list.py
@@ -101,7 +101,7 @@ class EventList():
     def __len__(self):
         return self._events.__len__()
 
-    def _match_event(self, event_pattern):
+    def _match_event(self, event_pattern='*'):
         matching_events = fnmatch.filter(self._events.keys(), event_pattern)
         if len(matching_events) == 0:
             logger.warning(

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except IOError:
     LONG_DESCRIPTION = hooker.__github__ + "/blob/master/README.md"
 
 if not hasattr(hooker, "__version__"):
-    hooker.__version__ = "develop"
+    hooker.__version__ = "0.0.0-dev"
 
 
 setup(

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -13,7 +13,7 @@ class TestGlob(unittest.TestCase):
         hooker.EVENTS.clear()
         # del os.environ["HOOKER_SCRIPTS"]
 
-    def test_wildcard_calling(self):
+    def test_wildcard_hooking(self):
 
     	hooker.EVENTS.append('test/1')
     	hooker.EVENTS.append('test/2')
@@ -36,4 +36,23 @@ class TestGlob(unittest.TestCase):
 
     	self.assertEqual(len(ret), 2)
     	self.assertEqual(ret.last[1], -1)
-    	
+
+
+    def test_wildcard_calling(self):
+
+        hooker.EVENTS.append('test/1')
+        hooker.EVENTS.append('test/2')
+        hooker.EVENTS.append('test')
+
+        @hooker.hook("test/1")
+        def a1(a):
+            return a + 1
+
+        @hooker.hook("test/2")
+        def a2(a):
+            return a - 2
+
+        ret = hooker.EVENTS.call('test/*', 1)
+        self.assertEqual(len(ret), 2)
+        self.assertEqual(ret['test/1'].last[1], 2)
+        self.assertEqual(ret['test/2'].last[1], -1)

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -32,7 +32,6 @@ class TestGlob(unittest.TestCase):
     		return -a
 
     	ret = hooker.EVENTS['test/2'](1)
-    	print(ret)
 
     	self.assertEqual(len(ret), 2)
     	self.assertEqual(ret.last[1], -1)

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1,0 +1,39 @@
+import unittest
+
+import os
+import hooker
+
+import logging
+logging.getLogger('hooker').setLevel(logging.DEBUG)
+
+
+class TestGlob(unittest.TestCase):
+
+    def tearDown(self):
+        hooker.EVENTS.clear()
+        # del os.environ["HOOKER_SCRIPTS"]
+
+    def test_wildcard_calling(self):
+
+    	hooker.EVENTS.append('test/1')
+    	hooker.EVENTS.append('test/2')
+    	hooker.EVENTS.append('test')
+
+    	@hooker.hook("test/*")
+    	def a1(a):
+    		return a + 1
+
+    	@hooker.hook("test/*")
+    	def a2(a):
+    		return a - 2
+
+    	@hooker.hook("test")
+    	def b(a):
+    		return -a
+
+    	ret = hooker.EVENTS['test/2'](1)
+    	print(ret)
+
+    	self.assertEqual(len(ret), 2)
+    	self.assertEqual(ret.last[1], -1)
+    	

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,0 +1,39 @@
+import unittest
+
+import os
+import hooker
+
+import logging
+logging.getLogger('hooker').setLevel(logging.DEBUG)
+
+
+class TestInputs(unittest.TestCase):
+
+    def setUp(self):
+        hooker.EVENTS.append("return_args")
+
+    def tearDown(self):
+        hooker.EVENTS.clear()
+        del os.environ["HOOKER_SCRIPTS"]
+        self.assertEqual(len(hooker.EVENTS), 0)
+
+    def test_plugin_as_module(self):
+        os.environ["HOOKER_SCRIPTS"] = 'tests.test_plugins.return_args'
+
+        results = hooker.EVENTS['return_args']('1', '2')
+
+        self.assertEqual(results.last[1], ('1', '2', 'test'))
+
+    def test_plugin_as_path(self):
+        os.environ["HOOKER_SCRIPTS"] = 'tests/test_plugins/return_args.py'
+
+        results = hooker.EVENTS['return_args']('3', '4')
+
+        self.assertEqual(results.last[1], ('3', '4', 'test'))
+
+    def test_plugin_as_relative_module(self):
+        os.environ["HOOKER_SCRIPTS"] = 'test_plugins.return_args'
+
+        results = hooker.EVENTS['return_args']('5', '6')
+
+        self.assertEqual(results.last[1], ('5', '6', 'test'))

--- a/tests/test_plugins/return_args.py
+++ b/tests/test_plugins/return_args.py
@@ -1,0 +1,7 @@
+import hooker
+
+
+@hooker.hook("return_args")
+def return_args_1(a, b):
+	print("'return_args_1' function - args '%s, %s'" %(a,b))
+	return a, b, 'test'


### PR DESCRIPTION
New things:

* Now you can use `wildcards` (`*`) in `hook`, to hook a function in more than one events. 
* You can use `EVENTS.call(pattern)` with an `pattern` containing a `wildcard` to call all events matching the `event`
* The patterns are evaluated with `fnmatch`, which is the same way Bash evaluates expressions
* The `hooker.get_event_name()` can be used from a hooked function, to get the name of the event that called it. This is useful for functions that are hooked to multiple events.